### PR TITLE
fixed running tests from setup.py

### DIFF
--- a/hpbandster/optimizers/iterations/successiveresampling.py
+++ b/hpbandster/optimizers/iterations/successiveresampling.py
@@ -21,8 +21,8 @@ class SuccessiveResampling(BaseIteration):
 					stage regardless of the fraction.
 		
 		"""
-			self.resampling_rate = resampling_rate
-			self.min_samples_advance = min_samples_advance
+		self.resampling_rate = resampling_rate
+		self.min_samples_advance = min_samples_advance
 
 
 	def _advance_to_next_stage(self, config_ids, losses):

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(
 		'docu': ['sphinx', 'sphinx_rtd_theme', 'sphinx_gallery'],
 	},
 	keywords=['distributed', 'optimization', 'multifidelity'],
+    	test_suite="tests"
 )


### PR DESCRIPTION
Currently test suite can't be run from setup.py, which prevents automatic package testing in some distros. This patch fixes it.