### PR TITLE
Fixed a minor bug in the get_pandas_dataframe function of Result

### DIFF
--- a/hpbandster/core/result.py
+++ b/hpbandster/core/result.py
@@ -511,7 +511,7 @@ class Result(object):
 				config['budget'] = r.budget
 
 			all_configs.append(config)
-			all_losses.append({'loss': r.loss})
+			all_losses.append(loss_fn(r))
 			
 			#df_x = df_x.append(config, ignore_index=True)
 			#df_y = df_y.append({'loss': r.loss}, ignore_index=True)


### PR DESCRIPTION
The `loss_fn` lambda was not being used and as a result, only the losses and not any info can be retrieved, for e.g by saying `loss_fn = lambda r: {"val_NLL": r.loss, "val_err": r.info['valid err']}`.

This PR does not change the default behaviour. 