### PR TITLE
Fix the Hyperband configuration formula

### DIFF
--- a/hpbandster/optimizers/hyperband.py
+++ b/hpbandster/optimizers/hyperband.py
@@ -89,7 +89,7 @@ class HyperBand(Master):
 		# number of 'SH rungs'
 		s = self.max_SH_iter - 1 - (iteration%self.max_SH_iter)
 		# number of configurations in that bracket
-		n0 = int(np.floor((self.max_SH_iter)/(s+1)) * self.eta**s)
+		n0 = int((self.max_SH_iter)/(s+1) * self.eta**s)
 		ns = [max(int(n0*(self.eta**(-i))), 1) for i in range(s+1)]
 
 		return(SuccessiveHalving(HPB_iter=iteration, num_configs=ns, budgets=self.budgets[(-s-1):], config_sampler=self.config_generator.get_config, **iteration_kwargs))


### PR DESCRIPTION
As highlighted in my blogpost [1], the formula used to computer the number of configurations for the successive halving step in hyperband deviates from the paper. In fact, there is an additional rounding operation on the s_max / (s+1) factor. Everything is explained in the blog post.

I also do not know why you are using an int() operator to round the value of n0 because it is originally a ceil operation. I suppose that this is why you need an additional max() in the computation of ns. The code is a bit intricated to me so I guess you can better tell than me. Do not hesitate to tell me if I can be of help or I am wrong.

[1] https://medium.com/data-from-the-trenches/a-slightly-better-budget-allocation-for-hyperband-bbd45af14481